### PR TITLE
Add "task" add command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TaskCommand.java
@@ -1,0 +1,8 @@
+package seedu.address.logic.commands;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+
+public abstract class TaskCommand extends Command {
+    public static final String COMMAND_WORD = "task";
+}

--- a/src/main/java/seedu/address/logic/commands/TaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/TaskCommand.java
@@ -1,8 +1,5 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Model;
-
 public abstract class TaskCommand extends Command {
     public static final String COMMAND_WORD = "task";
 }

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -1,13 +1,14 @@
 package seedu.address.logic.commands.task;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
+
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.task.Task;
-
-import static seedu.address.logic.parser.CliSyntax.*;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 public class AddTaskCommand extends TaskCommand {
     public static final String COMMAND_WORD = "add";

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -10,6 +10,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.task.Task;
 
+/**
+ * Adds a task to the task list.
+ */
 public class AddTaskCommand extends TaskCommand {
     public static final String COMMAND_WORD = "add";
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
@@ -32,6 +35,6 @@ public class AddTaskCommand extends TaskCommand {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         model.addTask(task);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, task.getTitle()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, task));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.commands.task;
+
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.TaskCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.task.Task;
+
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+public class AddTaskCommand extends TaskCommand {
+    public static final String COMMAND_WORD = "add";
+    public static final String MESSAGE_SUCCESS = "New task added: %1$s";
+    public static final String MESSAGE_USAGE = "task " + COMMAND_WORD
+            + ": Adds a task with a given title to the task list.\n"
+            + "Parameters: title (must be a non-empty string) "
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
+            + "[" + PREFIX_TIMESTAMP + "TIMESTAMP] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " Do homework "
+            + PREFIX_DESCRIPTION + "Physics assignment "
+            + PREFIX_TIMESTAMP + "25/12/2020";
+
+    private final Task task;
+
+    public AddTaskCommand(Task task) {
+        this.task = task;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        model.addTask(task);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, task.getTitle()));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -7,22 +7,26 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.TaskCommandParser;
 import seedu.address.model.Model;
 import seedu.address.model.task.Task;
+
+import javax.print.DocFlavor;
 
 /**
  * Adds a task to the task list.
  */
 public class AddTaskCommand extends TaskCommand {
     public static final String COMMAND_WORD = "add";
+    public static final String FULL_COMMAND_WORD = TaskCommand.COMMAND_WORD + " " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";
-    public static final String MESSAGE_USAGE = "task " + COMMAND_WORD
+    public static final String MESSAGE_USAGE = FULL_COMMAND_WORD
             + ": Adds a task with a given title to the task list.\n"
             + "Parameters: title (must be a non-empty string) "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
             + "[" + PREFIX_TIMESTAMP + "TIMESTAMP] "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "Example: " + COMMAND_WORD + " Do homework "
+            + "Example: " + FULL_COMMAND_WORD + " Do homework "
             + PREFIX_DESCRIPTION + "Physics assignment "
             + PREFIX_TIMESTAMP + "25/12/2020";
 

--- a/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/AddTaskCommand.java
@@ -7,11 +7,8 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.TaskCommandParser;
 import seedu.address.model.Model;
 import seedu.address.model.task.Task;
-
-import javax.print.DocFlavor;
 
 /**
  * Adds a task to the task list.

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +68,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case TaskCommand.COMMAND_WORD:
+            return new TaskCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -69,6 +69,7 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
+        // Every command starting with "task" delegated to TaskCommandParser
         case TaskCommand.COMMAND_WORD:
             return new TaskCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -12,4 +12,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
 
+    /* Task-related prefix definitions */
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
+    public static final Prefix PREFIX_TIMESTAMP = new Prefix("ts/");
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -14,6 +15,7 @@ import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Timestamp;
 
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
@@ -120,5 +122,10 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    public static Timestamp parseTimestamp(String timestamp) {
+        requireNonNull(timestamp);
+        return new Timestamp(timestamp);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
@@ -124,6 +123,11 @@ public class ParserUtil {
         return tagSet;
     }
 
+    /**
+     * Parses {@code String timestamp} into a {@code Timestamp}.
+     * @param timestamp The timestamp string to parse
+     * @return A parsed timestamp
+     */
     public static Timestamp parseTimestamp(String timestamp) {
         requireNonNull(timestamp);
         return new Timestamp(timestamp);

--- a/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
@@ -12,6 +12,9 @@ import seedu.address.logic.commands.task.AddTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.task.AddTaskCommandParser;
 
+/**
+ * Parses all task-related commands (those starting with "task") and returns a TaskCommand.
+ */
 public class TaskCommandParser implements Parser<TaskCommand> {
     /**
      * Used for initial separation of command word and args.

--- a/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.TaskCommand;
+import seedu.address.logic.commands.task.AddTaskCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.task.AddTaskCommandParser;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+
+public class TaskCommandParser implements Parser<TaskCommand> {
+    /**
+     * Used for initial separation of command word and args.
+     */
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+
+    @Override
+    public TaskCommand parse(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+        case AddTaskCommand.COMMAND_WORD:
+            return new AddTaskCommandParser().parse(arguments);
+        default:
+            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/TaskCommandParser.java
@@ -1,17 +1,16 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.task.AddTaskCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.task.AddTaskCommandParser;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-
 
 public class TaskCommandParser implements Parser<TaskCommand> {
     /**

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -17,6 +17,9 @@ import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Task;
 import seedu.address.model.task.Timestamp;
 
+/**
+ * Parses input arguments and creates a new AddTaskCommand object
+ */
 public class AddTaskCommandParser implements Parser<AddTaskCommand> {
     @Override
     public AddTaskCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser.task;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.task.AddTaskCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.Timestamp;
+
+import java.util.Set;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
+
+public class AddTaskCommandParser implements Parser<AddTaskCommand> {
+    @Override
+    public AddTaskCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_TIMESTAMP, PREFIX_TAG);
+
+        String title = argMultimap.getPreamble();
+        if (title.isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddTaskCommand.MESSAGE_USAGE));
+        }
+        String description = argMultimap.getValue(PREFIX_DESCRIPTION).orElse(null);
+        Timestamp timestamp = argMultimap.getValue(PREFIX_TIMESTAMP).map(ParserUtil::parseTimestamp).orElse(null);
+        Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+        return new AddTaskCommand(new Task(title, description, timestamp, tags));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/AddTaskCommandParser.java
@@ -1,28 +1,27 @@
 package seedu.address.logic.parser.task;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.task.AddTaskCommand;
-import seedu.address.logic.parser.ArgumentMultimap;
-import seedu.address.logic.parser.ArgumentTokenizer;
-import seedu.address.logic.parser.Parser;
-import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.Prefix;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.tag.Tag;
-import seedu.address.model.task.Task;
-import seedu.address.model.task.Timestamp;
-
-import java.util.Set;
-
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMESTAMP;
 
+import java.util.Set;
+
+import seedu.address.logic.commands.task.AddTaskCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.Timestamp;
+
 public class AddTaskCommandParser implements Parser<AddTaskCommand> {
     @Override
     public AddTaskCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_TIMESTAMP, PREFIX_TAG);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_DESCRIPTION, PREFIX_TIMESTAMP, PREFIX_TAG);
 
         String title = argMultimap.getPreamble();
         if (title.isEmpty()) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
 
 /**
  * The API of the Model component.
@@ -84,4 +85,10 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Adds the given task to the task list.
+     * @param task The task to be added
+     */
+    void addTask(Task task);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -12,6 +14,7 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -22,6 +25,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final List<Task> tasks;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +39,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        tasks = new ArrayList<>();
     }
 
     public ModelManager() {
@@ -127,6 +132,11 @@ public class ModelManager implements Model {
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void addTask(Task task) {
+        tasks.add(task);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -1,0 +1,46 @@
+package seedu.address.model.task;
+
+import seedu.address.model.tag.Tag;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Represents a Task in the task list.
+ * Guarantees: title is present and not null, field values are validated, immutable.
+ */
+public class Task {
+    private final String title;
+
+    // Optional description fields
+    private final String description;
+    private final Timestamp timestamp;
+    private final Set<Tag> tags = new HashSet<>();
+
+    public Task(String title, String description, Timestamp timestamp, Set<Tag> tags) {
+        requireAllNonNull(title, tags);
+
+        this.title = title;
+        this.description = description;
+        this.timestamp = timestamp;
+        this.tags.addAll(tags);
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Timestamp getTimestamp() {
+        return timestamp;
+    }
+
+    public Set<Tag> getTags() {
+        return tags;
+    }
+}

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -50,4 +50,9 @@ public class Task {
     public Set<Tag> getTags() {
         return tags;
     }
+
+    @Override
+    public String toString() {
+        return title;
+    }
 }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -1,11 +1,11 @@
 package seedu.address.model.task;
 
-import seedu.address.model.tag.Tag;
-
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.HashSet;
 import java.util.Set;
+
+import seedu.address.model.tag.Tag;
 
 /**
  * Represents a Task in the task list.
@@ -19,6 +19,13 @@ public class Task {
     private final Timestamp timestamp;
     private final Set<Tag> tags = new HashSet<>();
 
+    /**
+     * Creates a task with a given title, and optionally a description, timestamp and a set of tags.
+     * @param title The title of the task
+     * @param description The optional description of the task
+     * @param timestamp The optional timestamp of the task
+     * @param tags The tags of the task
+     */
     public Task(String title, String description, Timestamp timestamp, Set<Tag> tags) {
         requireAllNonNull(title, tags);
 

--- a/src/main/java/seedu/address/model/task/Timestamp.java
+++ b/src/main/java/seedu/address/model/task/Timestamp.java
@@ -1,9 +1,18 @@
 package seedu.address.model.task;
 
+/**
+ * Represents a timestamp for a task.
+ */
 public class Timestamp {
     private final String timestamp;
 
+    /**
+     * Creates a TimeStamp with the given string.
+     * @param timestamp the string representing the timestamp
+     */
     public Timestamp(String timestamp) {
         this.timestamp = timestamp;
     }
+
+    // TODO: Create a DateTime representation of timestamps
 }

--- a/src/main/java/seedu/address/model/task/Timestamp.java
+++ b/src/main/java/seedu/address/model/task/Timestamp.java
@@ -1,0 +1,9 @@
+package seedu.address.model.task;
+
+public class Timestamp {
+    private final String timestamp;
+
+    public Timestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.Task;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandTest {
@@ -145,6 +146,11 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addTask(Task task) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
# Changes

- Adds `task add` command
- Adds line in `AddressBookParser` to delegate commands starting with `task` to `TaskCommandParser`
- Adds Timestamp class for abstraction purposes

## Parsing logic

Parsing is done in [AddressBookParser](https://github.com/jeffsieu/tp/blob/ed997b8be4403b38e9af59792191ac330ad27b55/src/main/java/seedu/address/logic/parser/AddressBookParser.java) for address book related commands. This logic is extended by delegating all commands starting with `task` to `TaskCommandParser`, which then parses the subcommand again, as a base command.

For example: 

```
task add <arg1> <arg2>
```

will be delegated to `TaskCommandParser`, which then parses the subcommand, i.e.:

```
add <arg1> <arg2>
```

## Tasks

For now, `Task`s have a title, and optionally a description, timestamp and a set of tags.

Tasks are created using the following syntax.

```
task add title d/Description ts/timestamp t/Tag 1 t/Tag 2
```

A `Timestamp` class is created for each task for abstraction purposes, and the existing `Tag` class from the AddressBook code is reused for tagging tasks as they seem suitable for usage.