### PR TITLE
Update docs title to "TaskMaster2103"

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,4 @@
-title: "AB-3"
+title: "TaskMaster2103"
 theme: jekyll-theme-merlot
 
 header_pages:
@@ -8,7 +8,7 @@ header_pages:
 
 markdown: kramdown
 
-repository: "se-edu/addressbook-level3"
+repository: "AY2122S1-CS2103-F09-2/tp"
 github_icon: "images/github-icon.png"
 
 plugins:

--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "TaskMaster2103";
     font-size: 32px;
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: page
 title: AddressBook Level-3
 ---
 
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/AY2122S1-CS2103-F09-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2122S1-CS2103-F09-2/tp/actions)
 [![codecov](https://codecov.io/gh/AY2122S1-CS2103-F09-2/tp/branch/master/graph/badge.svg?token=N3P0ba1qaC)](https://codecov.io/gh/AY2122S1-CS2103-F09-2/tp)
 
 ![Ui](images/Ui.png)
@@ -13,7 +13,6 @@ title: AddressBook Level-3
 * If you are interested in using AddressBook, head over to the [_Quick Start_ section of the **User Guide**](UserGuide.html#quick-start).
 * If you are interested about developing AddressBook, the [**Developer Guide**](DeveloperGuide.html) is a good place to start.
 
-
-**Acknowledgements**
+## Acknowledgements
 
 * Libraries used: [JavaFX](https://openjfx.io/), [Jackson](https://github.com/FasterXML/jackson), [JUnit5](https://github.com/junit-team/junit5)


### PR DESCRIPTION
Updates jekyll config to generate docs with title as "TaskMaster2103" instead of "AB-3"

Also updates the index.md (root page) of the docs to use the badge for the tp workflow instead of the se-education workflow.

Resolves #7 