### PR TITLE
ci: Update gradle.yml to do whitespace check last.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,11 +21,6 @@ jobs:
       - name: Merge to master
         run: git checkout --progress --force ${{ github.sha }}
 
-      - name: Run repository-wide tests
-        if: runner.os == 'Linux'
-        working-directory:  ${{ github.workspace }}/.github
-        run: ./run-checks.sh
-
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
@@ -37,6 +32,11 @@ jobs:
 
       - name: Build and check with Gradle
         run: ./gradlew check coverage
+
+      - name: Run repository-wide tests
+        if: runner.os == 'Linux'
+        working-directory:  ${{ github.workspace }}/.github
+        run: ./run-checks.sh
 
       - uses: codecov/codecov-action@v1
         if: runner.os == 'Linux'


### PR DESCRIPTION
Prevents premature exit from whitespace checks.

Does the whitespace checks at the end instead of at the start. Allows for gradle to run first.