### PR TITLE
Refactor TaskFilters into subclass implementations of TaskFilter

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -13,7 +13,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyTaskList;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.ui.exceptions.GuiException;
 
 /**

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -19,7 +19,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyTaskList;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.storage.Storage;
 import seedu.address.ui.exceptions.GuiException;
 

--- a/src/main/java/seedu/address/logic/commands/task/FindTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/FindTaskCommand.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.task.TaskContainsKeywordsPredicate;
+import seedu.address.model.task.filters.KeywordTaskFilter;
 import seedu.address.model.task.filters.TaskFilters;
 
 
@@ -39,7 +40,7 @@ public class FindTaskCommand extends TaskCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        model.getSelectedTaskFilters().stream().filter(filter -> filter instanceof TaskFilters.KeywordTaskFilter)
+        model.getSelectedTaskFilters().stream().filter(filter -> filter instanceof KeywordTaskFilter)
                 .findFirst().ifPresent(model::removeTaskFilter);
 
         if (!predicate.equals(TaskContainsKeywordsPredicate.SHOW_ALL_TASKS_PREDICATE)) {

--- a/src/main/java/seedu/address/logic/commands/task/ListTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTaskCommand.java
@@ -11,7 +11,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.TaskCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilter;
 
 /**
  * Completes an existing task in the task list.

--- a/src/main/java/seedu/address/logic/parser/task/ListTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/ListTaskCommandParser.java
@@ -15,8 +15,8 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.model.task.filters.TaskFilters;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
 
 public class ListTaskCommandParser implements Parser<ListTaskCommand> {
     /**
@@ -36,7 +36,7 @@ public class ListTaskCommandParser implements Parser<ListTaskCommand> {
         }
 
         if (argMultimap.getValue(PREFIX_UNDONE).isPresent()) {
-            taskFilters.add(TaskFilters.FILTER_DONE.invert());
+            taskFilters.add(TaskFilters.FILTER_UNDONE);
         }
 
         if (!argMultimap.getPreamble().isEmpty()) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -9,7 +9,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.guiactions.GuiAction;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.storage.CommandHistory;
 
 /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -21,8 +21,8 @@ import seedu.address.logic.guiactions.GuiAction;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.task.Task;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.model.task.filters.TaskFilters;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
 import seedu.address.storage.CommandHistory;
 
 /**
@@ -203,7 +203,7 @@ public class ModelManager implements Model {
 
         availableTaskFilters.clear();
         availableTaskFilters.add(TaskFilters.FILTER_DONE);
-        availableTaskFilters.add(TaskFilters.FILTER_DONE.invert());
+        availableTaskFilters.add(TaskFilters.FILTER_UNDONE);
         availableTaskFilters.addAll(tagFilters);
     }
 

--- a/src/main/java/seedu/address/model/task/filters/DoneTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/DoneTaskFilter.java
@@ -1,0 +1,40 @@
+package seedu.address.model.task.filters;
+
+import java.util.Objects;
+
+import seedu.address.model.task.Task;
+
+class DoneTaskFilter extends TaskFilter {
+    DoneTaskFilter() {
+        this(false);
+    }
+
+    private DoneTaskFilter(boolean isInverted) {
+        super(Task::getIsDone, isInverted);
+    }
+
+    @Override
+    public String toDisplayString() {
+        return isInverted ? "Undone" : "Done";
+    }
+
+    @Override
+    public DoneTaskFilter invert() {
+        return new DoneTaskFilter(!isInverted);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        return (o instanceof DoneTaskFilter)
+                && isInverted == ((DoneTaskFilter) o).isInverted;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(isInverted);
+    }
+}

--- a/src/main/java/seedu/address/model/task/filters/KeywordTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/KeywordTaskFilter.java
@@ -1,0 +1,36 @@
+package seedu.address.model.task.filters;
+
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.task.Task;
+import seedu.address.model.task.TaskContainsKeywordsPredicate;
+
+public class KeywordTaskFilter extends TaskFilter {
+    private static final int MAX_KEYWORDS_LENGTH = 35;
+    private final String keywords;
+
+    KeywordTaskFilter(TaskContainsKeywordsPredicate predicate) {
+        this(predicate, predicate.getKeywords(), false);
+    }
+
+    private KeywordTaskFilter(
+        Predicate<Task> predicate,
+        String keywords,
+        boolean isInverted
+    ) {
+        super(predicate, isInverted);
+        this.keywords = keywords;
+    }
+
+    @Override
+    public TaskFilter invert() {
+        return new KeywordTaskFilter(predicate.negate(), this.keywords, !isInverted);
+    }
+
+    @Override
+    public String toDisplayString() {
+        return (this.isInverted ? "Without " : "Contains ")
+                + StringUtil.limitString(keywords, "...", KeywordTaskFilter.MAX_KEYWORDS_LENGTH);
+    }
+}

--- a/src/main/java/seedu/address/model/task/filters/TagTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/TagTaskFilter.java
@@ -1,0 +1,42 @@
+package seedu.address.model.task.filters;
+
+import seedu.address.model.tag.Tag;
+
+public class TagTaskFilter extends TaskFilter {
+    private final Tag tag;
+
+    TagTaskFilter(Tag tag) {
+        this(tag, false);
+    }
+
+    private TagTaskFilter(Tag tag, boolean isInverted) {
+        super(task -> task.getTags().contains(tag), isInverted);
+        this.tag = tag;
+    }
+
+    @Override
+    public String toDisplayString() {
+        return (isInverted ? "Not tagged " : "Tagged ") + tag;
+    }
+
+    @Override
+    public TagTaskFilter invert() {
+        return new TagTaskFilter(tag, !isInverted);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        return (o instanceof TagTaskFilter)
+                && isInverted == ((TagTaskFilter) o).isInverted
+                && tag.equals(((TagTaskFilter) o).tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return tag.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/model/task/filters/TaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/TaskFilter.java
@@ -1,0 +1,39 @@
+package seedu.address.model.task.filters;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import seedu.address.model.task.Task;
+
+public abstract class TaskFilter {
+    protected Predicate<Task> predicate;
+    protected boolean isInverted;
+    protected Function<Boolean, String> toString;
+
+    TaskFilter(Predicate<Task> predicate, boolean isInverted) {
+        this.predicate = predicate;
+        this.isInverted = isInverted;
+    }
+
+    /**
+     * Returns the predicate used to filter tasks.
+     *
+     * @return The predicate used to filter tasks
+     */
+    public Predicate<Task> getPredicate() {
+        return this.predicate;
+    }
+
+    /**
+     * Returns a new task filter that accepts tasks not accepted by this task filter, and vice-versa.
+     *
+     * @return A new task filter with an inverted predicate
+     */
+    public abstract TaskFilter invert();
+
+    /**
+     * Returns the string used to describe the filter in the UI.
+     * @return the string used to describe the filter in the UI
+     */
+    public abstract String toDisplayString();
+}

--- a/src/main/java/seedu/address/model/task/filters/TaskFilters.java
+++ b/src/main/java/seedu/address/model/task/filters/TaskFilters.java
@@ -1,81 +1,13 @@
 package seedu.address.model.task.filters;
 
 import java.util.function.Function;
-import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
 import seedu.address.model.tag.Tag;
-import seedu.address.model.task.Task;
 import seedu.address.model.task.TaskContainsKeywordsPredicate;
 
 public class TaskFilters {
-
-    public static final TaskFilter FILTER_DONE = new TaskFilter(Task::getIsDone,
-        isInverted -> isInverted ? "Undone" : "Done");
-    public static final Function<Tag, TaskFilter> FILTER_TAG = tag -> new TaskFilter(
-        task -> task.getTags().contains(tag), isInverted -> (isInverted ? "Not tagged " : "Tagged ") + tag);
-
-    public static final Function<TaskContainsKeywordsPredicate, TaskFilter> FILTER_KEYWORDS = predicate ->
-            new KeywordTaskFilter(predicate, x -> "Contains "
-            + StringUtil.limitString(predicate.getKeywords(), "...", KeywordTaskFilter.MAX_KEYWORDS_LENGTH));
-
-    public static class KeywordTaskFilter extends TaskFilter {
-        private static final int MAX_KEYWORDS_LENGTH = 35;
-        private KeywordTaskFilter(Predicate<Task> predicate, Function<Boolean, String> toString) {
-            super(predicate, toString);
-        }
-    }
-
-    public static class TaskFilter {
-        private Predicate<Task> predicate;
-        private boolean isInverted;
-        private Function<Boolean, String> toString;
-
-        private TaskFilter(Predicate<Task> predicate, Function<Boolean, String> toString) {
-            this(predicate, toString, false);
-        }
-
-        private TaskFilter(Predicate<Task> predicate, Function<Boolean, String> toString, boolean isInverted) {
-            this.predicate = predicate;
-            this.toString = toString;
-            this.isInverted = isInverted;
-        }
-
-        /**
-         * Returns the predicate used to filter tasks.
-         * @return The predicate used to filter tasks
-         */
-        public Predicate<Task> getPredicate() {
-            return this.predicate;
-        }
-
-        /**
-         * Returns a new task filter that accepts tasks not accepted by this task filter, and vice-versa.
-         * @return A new task filter with an inverted predicate
-         */
-        public TaskFilter invert() {
-            return new TaskFilter(predicate.negate(), this.toString, !isInverted);
-        }
-
-        @Override
-        public String toString() {
-            return toString.apply(this.isInverted);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-
-            return (o instanceof TaskFilter)
-                    && isInverted == ((TaskFilter) o).isInverted
-                    && this.toString().equals(o.toString());
-        }
-
-        @Override
-        public int hashCode() {
-            return this.toString().hashCode();
-        }
-    }
+    public static final TaskFilter FILTER_DONE = new DoneTaskFilter();
+    public static final TaskFilter FILTER_UNDONE = new DoneTaskFilter().invert();
+    public static final Function<Tag, TaskFilter> FILTER_TAG = TagTaskFilter::new;
+    public static final Function<TaskContainsKeywordsPredicate, TaskFilter> FILTER_KEYWORDS = KeywordTaskFilter::new;
 }

--- a/src/main/java/seedu/address/ui/TaskFilterCell.java
+++ b/src/main/java/seedu/address/ui/TaskFilterCell.java
@@ -1,19 +1,19 @@
 package seedu.address.ui;
 
 import javafx.scene.control.cell.ComboBoxListCell;
-import seedu.address.model.task.filters.TaskFilters;
+import seedu.address.model.task.filters.TaskFilter;
 
-public class TaskFilterCell extends ComboBoxListCell<TaskFilters.TaskFilter> {
+public class TaskFilterCell extends ComboBoxListCell<TaskFilter> {
 
     @Override
-    public void updateItem(TaskFilters.TaskFilter taskFilter, boolean empty) {
+    public void updateItem(TaskFilter taskFilter, boolean empty) {
         super.updateItem(taskFilter, empty);
 
         setGraphic(null);
         if (empty || taskFilter == null) {
             setText(null);
         } else {
-            setText(taskFilter.toString());
+            setText(taskFilter.toDisplayString());
         }
     }
 }

--- a/src/main/java/seedu/address/ui/TaskFilterChip.java
+++ b/src/main/java/seedu/address/ui/TaskFilterChip.java
@@ -6,7 +6,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilter;
 
 public class TaskFilterChip extends UiPart<Region> {
     @FXML
@@ -22,7 +22,7 @@ public class TaskFilterChip extends UiPart<Region> {
      */
     public TaskFilterChip(TaskFilter taskFilter, Consumer<TaskFilter> removeTaskFilter) {
         super("TaskFilterChip.fxml");
-        filterNameLabel.setText(taskFilter.toString());
+        filterNameLabel.setText(taskFilter.toDisplayString());
         removeButton.setOnAction((actionEvent) -> removeTaskFilter.accept(taskFilter));
     }
 }

--- a/src/main/java/seedu/address/ui/TaskFilterChipCell.java
+++ b/src/main/java/seedu/address/ui/TaskFilterChipCell.java
@@ -1,11 +1,11 @@
 package seedu.address.ui;
 
 import javafx.scene.control.ListCell;
-import seedu.address.model.task.filters.TaskFilters;
+import seedu.address.model.task.filters.TaskFilter;
 
-public class TaskFilterChipCell extends ListCell<TaskFilters.TaskFilter> {
+public class TaskFilterChipCell extends ListCell<TaskFilter> {
     @Override
-    protected void updateItem(TaskFilters.TaskFilter taskFilter, boolean empty) {
+    protected void updateItem(TaskFilter taskFilter, boolean empty) {
         super.updateItem(taskFilter, empty);
 
         setText(null);

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -11,7 +11,7 @@ import javafx.scene.control.ListView;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import seedu.address.model.task.Task;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.ui.exceptions.GuiException;
 
 public class TaskListPanel extends UiPart<Region> {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -25,7 +25,7 @@ import seedu.address.model.ReadOnlyTaskList;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
 import seedu.address.model.task.Task;
-import seedu.address.model.task.filters.TaskFilters;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.storage.CommandHistory;
 import seedu.address.testutil.PersonBuilder;
 
@@ -165,32 +165,32 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<TaskFilters.TaskFilter> getAvailableTaskFilters() {
+        public ObservableList<TaskFilter> getAvailableTaskFilters() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public ObservableList<TaskFilters.TaskFilter> getSelectedTaskFilters() {
+        public ObservableList<TaskFilter> getSelectedTaskFilters() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void addTaskFilter(TaskFilters.TaskFilter taskFilter) {
+        public void addTaskFilter(TaskFilter taskFilter) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void removeTaskFilter(TaskFilters.TaskFilter taskFilter) {
+        public void removeTaskFilter(TaskFilter taskFilter) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setTaskFilters(List<TaskFilters.TaskFilter> taskFilter) {
+        public void setTaskFilters(List<TaskFilter> taskFilter) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public List<TaskFilters.TaskFilter> getOldTaskFilters() {
+        public List<TaskFilter> getOldTaskFilters() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/task/ListTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/task/ListTaskCommandTest.java
@@ -15,8 +15,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.model.task.filters.TaskFilters;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
 
 public class ListTaskCommandTest {
     private final Model model = new ModelManager(getTypicalAddressBook(), getTypicalTaskList(), new UserPrefs());

--- a/src/test/java/seedu/address/logic/parser/task/ListTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/ListTaskCommandParserTest.java
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.task.ListTaskCommand;
 import seedu.address.model.tag.Tag;
+import seedu.address.model.task.filters.TaskFilter;
 import seedu.address.model.task.filters.TaskFilters;
-import seedu.address.model.task.filters.TaskFilters.TaskFilter;
 
 public class ListTaskCommandParserTest {
     private final ListTaskCommandParser parser = new ListTaskCommandParser();


### PR DESCRIPTION
Refactors TaskFilters into subclasses instead of relying on lambda expressions to define behaviour. This allows us to check if a particular filter is `DoneTaskFilter` or `TagTaskFilter` instead of having all of them as instances of `TaskFilter`. This should allow for more complex behaviour like only allowing filtering by `Done` or `Undone` at one time.

This will also help with #76 in the implementation of removing the existing find filter.