### PR TITLE
Deconflict task filters

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,7 +207,7 @@ Tasks can be filtered by completion status and/or tags. Show only completed task
 
 **Format:**
 
-`task list [done/ OR undone/] [t/TAG]...`
+`task list [done/ OR undone/] [t/TAG]…`
 
 ### Editing a task: `task edit`
 
@@ -215,7 +215,7 @@ Edits an existing task in the task list
 
 **Format:**
 
-`task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG] [c/CONTACT]...`
+`task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG] [c/CONTACT]…`
 
 - Edits the task at the specified INDEX. The index refers to the index number shown in the displayed task list. The index must be a positive integer 1,2,3 …
 - At least one of the optional fields must be provided
@@ -349,16 +349,16 @@ If your changes to the data file makes its format invalid, TaskMaster will disca
 | Action          | Format, Examples                                                                                                                                                      |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |***Address Book Commands*** |
-| **Add**         | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague` |
+| **Add**         | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague` |
 | **List**        | `list`                                                                                                                                                                |
-| **Edit**        | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]...`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                           |
+| **Edit**        | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                           |
 | **Find**        | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                            |
 | **Delete**      | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                   |
 | **Clear**       | `clear`                                                                                                                                                               |
 |***Task List Commands***    |
 | **Task Add**    | `task add TITLE [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG]`                                                                                                             |
-| **Task List**   | `task list [done/ OR undone/] [t/TAG]...` |
-| **Task Edit**   | `task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG]...` <br> e.g.,`task edit 1 t/CS2103 Week 6 Quiz`                                                    |
+| **Task List**   | `task list [done/ OR undone/] [t/TAG]…` |
+| **Task Edit**   | `task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG]…` <br> e.g.,`task edit 1 t/CS2103 Week 6 Quiz`                                                    |
 | **Task Find**   | `task find KEYWORD [MORE_KEYWORDS]`|
 | **Task Delete** | `task delete INDEX`<br> e.g., `task delete 3`                                                                                                                         |
 | **Task Purge** | `task purge`                                                                                                                         |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -203,9 +203,11 @@ Lists all tasks in the task list. Clears any existing filters.
 
 Tasks can be filtered by completion status and/or tags. Show only completed tasks with `done/`, pending tasks with `undone/` and tasks with a certain tag `TAG` with `tag/TAG`.
 
+> Note: `undone/` and `done/` flags cannot be specified at the same time.
+
 **Format:**
 
-`task list [done/] [undone/] [t/TAG]`
+`task list [done/ OR undone/] [t/TAG]...`
 
 ### Editing a task: `task edit`
 
@@ -213,7 +215,7 @@ Edits an existing task in the task list
 
 **Format:**
 
-`task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG] [c/CONTACT]…`
+`task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG] [c/CONTACT]...`
 
 - Edits the task at the specified INDEX. The index refers to the index number shown in the displayed task list. The index must be a positive integer 1,2,3 …
 - At least one of the optional fields must be provided
@@ -347,16 +349,16 @@ If your changes to the data file makes its format invalid, TaskMaster will disca
 | Action          | Format, Examples                                                                                                                                                      |
 | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |***Address Book Commands*** |
-| **Add**         | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague` |
+| **Add**         | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]...` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague` |
 | **List**        | `list`                                                                                                                                                                |
-| **Edit**        | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                           |
+| **Edit**        | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]...`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`                                           |
 | **Find**        | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`                                                                                                            |
 | **Delete**      | `delete INDEX`<br> e.g., `delete 3`                                                                                                                                   |
 | **Clear**       | `clear`                                                                                                                                                               |
 |***Task List Commands***    |
-| **Task Add**    | `task add TITLE [d/DESCRIPTION] [ts/TIMESTAMP] [tag/TAG}`                                                                                                             |
-| **Task List**   | `task list [done/] [undone/] [t/TAG]` |
-| **Task Edit**   | `task edit INDEX [t/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [tag/TAG]…` <br> e.g.,`task edit 1 t/CS2103 Week 6 Quiz`                                                    |
+| **Task Add**    | `task add TITLE [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG]`                                                                                                             |
+| **Task List**   | `task list [done/ OR undone/] [t/TAG]...` |
+| **Task Edit**   | `task edit INDEX [ti/TITLE] [d/DESCRIPTION] [ts/TIMESTAMP] [t/TAG]...` <br> e.g.,`task edit 1 t/CS2103 Week 6 Quiz`                                                    |
 | **Task Find**   | `task find KEYWORD [MORE_KEYWORDS]`|
 | **Task Delete** | `task delete INDEX`<br> e.g., `task delete 3`                                                                                                                         |
 | **Task Purge** | `task purge`                                                                                                                         |

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -57,7 +57,7 @@ public interface Logic {
      * Returns a list of available task filters.
      * @return The list of available task filters
      */
-    ObservableList<TaskFilter> getAvailableTaskFilters();
+    ObservableList<TaskFilter> getSelectableTaskFilters();
 
     /**
      * Returns the list of selected filters to filter tasks by.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -91,8 +91,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public ObservableList<TaskFilter> getAvailableTaskFilters() {
-        return model.getAvailableTaskFilters();
+    public ObservableList<TaskFilter> getSelectableTaskFilters() {
+        return model.getSelectableTaskFilters();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/task/ListTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/ListTaskCommand.java
@@ -20,6 +20,7 @@ public class ListTaskCommand extends TaskCommand {
     public static final String COMMAND_WORD = "list";
     public static final String FULL_COMMAND_WORD = TaskCommand.COMMAND_WORD + " " + COMMAND_WORD;
     public static final String MESSAGE_SUCCESS = "Task list updated";
+    public static final String MESSAGE_ONE_DONE_FILTER = "Tasks can only be filtered by done or undone at one time.";
     public static final String MESSAGE_USAGE = FULL_COMMAND_WORD
             + ": Lists tasks matching the given search conditions.\n"
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/parser/task/ListTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/ListTaskCommandParser.java
@@ -48,7 +48,7 @@ public class ListTaskCommandParser implements Parser<ListTaskCommand> {
 
         // Both done and undone flags are present
         if (argMultimap.getValue(PREFIX_DONE).isPresent()
-                && argMultimap.getValue(PREFIX_DONE).isPresent()) {
+                && argMultimap.getValue(PREFIX_UNDONE).isPresent()) {
             throw new ParseException(MESSAGE_ONE_DONE_FILTER + "\n" + MESSAGE_USAGE);
         }
 

--- a/src/main/java/seedu/address/logic/parser/task/ListTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/ListTaskCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser.task;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.task.ListTaskCommand.MESSAGE_ONE_DONE_FILTER;
 import static seedu.address.logic.commands.task.ListTaskCommand.MESSAGE_USAGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -44,6 +45,12 @@ public class ListTaskCommandParser implements Parser<ListTaskCommand> {
 
         Set<Tag> tags = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
         List<TaskFilter> taskFilters = tags.stream().map(TaskFilters.FILTER_TAG).collect(Collectors.toList());
+
+        // Both done and undone flags are present
+        if (argMultimap.getValue(PREFIX_DONE).isPresent()
+                && argMultimap.getValue(PREFIX_DONE).isPresent()) {
+            throw new ParseException(MESSAGE_ONE_DONE_FILTER + "\n" + MESSAGE_USAGE);
+        }
 
         if (argMultimap.getValue(PREFIX_DONE).isPresent()) {
             taskFilters.add(TaskFilters.FILTER_DONE);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -138,8 +138,8 @@ public interface Model {
 
 
     /**
-     * Returns a list of available task filters.
-     * @return The list of available task filters.
+     * Returns a list of selectable task filters.
+     * @return The list of selectable task filters.
      */
     ObservableList<TaskFilter> getSelectableTaskFilters();
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -141,7 +141,7 @@ public interface Model {
      * Returns a list of available task filters.
      * @return The list of available task filters.
      */
-    ObservableList<TaskFilter> getAvailableTaskFilters();
+    ObservableList<TaskFilter> getSelectableTaskFilters();
 
     /**
      * Returns the list of selected filters to filter tasks by.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -44,6 +44,7 @@ public class ModelManager implements Model {
     private final FilteredList<Person> filteredPersons;
     private final FilteredList<Task> filteredTasks;
     private final ObservableList<TaskFilter> availableTaskFilters;
+    private final FilteredList<TaskFilter> selectableTaskFilters;
     private final ObservableList<TaskFilter> selectedTaskFilters;
 
     /**
@@ -63,9 +64,9 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         filteredTasks = new FilteredList<>(this.taskList.getTasks());
         availableTaskFilters = FXCollections.observableArrayList();
+        selectableTaskFilters = new FilteredList<>(availableTaskFilters,
+            filter -> getSelectedTaskFilters().stream().noneMatch(filter::hasConflictWith));
         selectedTaskFilters = FXCollections.observableArrayList();
-
-
     }
 
     public ModelManager() {
@@ -74,12 +75,13 @@ public class ModelManager implements Model {
 
     /**
      * Returns a new ModelManager initialize from the given {@link Model}.
+     *
      * @param model The model to initialize the {@link ModelManager} from
      * @return The initialized ModelManager
      */
     public static ModelManager from(Model model) {
         return new ModelManager(
-                new AddressBook(model.getAddressBook()), new TaskList(model.getTaskList()) , new UserPrefs());
+                new AddressBook(model.getAddressBook()), new TaskList(model.getTaskList()), new UserPrefs());
     }
 
     //=========== UserPrefs ==================================================================================
@@ -160,7 +162,6 @@ public class ModelManager implements Model {
     }
 
 
-
     //=========== Filtered Person List Accessors =============================================================
 
     /**
@@ -229,10 +230,15 @@ public class ModelManager implements Model {
         availableTaskFilters.addAll(tagFilters);
     }
 
+    private void refreshSelectableTaskFiltersPredicate() {
+        selectableTaskFilters.setPredicate(
+            filter -> getSelectedTaskFilters().stream().noneMatch(filter::hasConflictWith));
+    }
+
     @Override
-    public ObservableList<TaskFilter> getAvailableTaskFilters() {
+    public ObservableList<TaskFilter> getSelectableTaskFilters() {
         recomputeAvailableTaskFilters();
-        return availableTaskFilters;
+        return selectableTaskFilters;
     }
 
     @Override
@@ -244,12 +250,14 @@ public class ModelManager implements Model {
     public void addTaskFilter(TaskFilter taskFilter) {
         selectedTaskFilters.add(taskFilter);
         recalculateFilteredTaskList();
+        refreshSelectableTaskFiltersPredicate();
     }
 
     @Override
     public void removeTaskFilter(TaskFilter taskFilter) {
         selectedTaskFilters.remove(taskFilter);
         recalculateFilteredTaskList();
+        refreshSelectableTaskFiltersPredicate();
     }
 
     @Override
@@ -257,6 +265,7 @@ public class ModelManager implements Model {
         selectedTaskFilters.clear();
         selectedTaskFilters.addAll(taskFilters);
         recalculateFilteredTaskList();
+        refreshSelectableTaskFiltersPredicate();
     }
 
     @Override
@@ -388,7 +397,7 @@ public class ModelManager implements Model {
     /**
      * Determines if a name exists within a given a list of {@code Person}s.
      *
-     * @param personList List of Persons to check through
+     * @param personList  List of Persons to check through
      * @param nameToCheck Name to check the list with
      * @return Boolean indicating whether the personList contains nameToCheck.
      */
@@ -414,7 +423,7 @@ public class ModelManager implements Model {
      * Changes the {@code oldName} in the given {@code Task} to the new name.
      * Used when a {@code Person}'s {@code Name} is edited.
      *
-     * @param task Given task to update
+     * @param task    Given task to update
      * @param oldName Old name to change
      * @param newName New name to change to
      * @return A new copy of the changed task. If there is no change, the task itself is returned.
@@ -431,11 +440,11 @@ public class ModelManager implements Model {
         return updatedContacts.equals(currentContactList)
                 ? task
                 : new Task(task.getTitle(),
-                        task.getDescription().orElse(null),
-                        task.getTimestamp().orElse(null),
-                        task.getTags(),
-                        task.isDone(),
-                        updatedContacts);
+                task.getDescription().orElse(null),
+                task.getTimestamp().orElse(null),
+                task.getTags(),
+                task.isDone(),
+                updatedContacts);
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/filters/DoneTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/DoneTaskFilter.java
@@ -19,6 +19,11 @@ class DoneTaskFilter extends TaskFilter {
     }
 
     @Override
+    public boolean hasConflictWith(TaskFilter other) {
+        return other instanceof DoneTaskFilter;
+    }
+
+    @Override
     public DoneTaskFilter invert() {
         return new DoneTaskFilter(!isInverted);
     }

--- a/src/main/java/seedu/address/model/task/filters/KeywordTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/KeywordTaskFilter.java
@@ -37,11 +37,7 @@ public class KeywordTaskFilter extends TaskFilter {
 
     @Override
     public boolean hasConflictWith(TaskFilter other) {
-        if (!(other instanceof KeywordTaskFilter)) {
-            return false;
-        }
-        KeywordTaskFilter otherKeywordTaskFilter = (KeywordTaskFilter) other;
-        return keywords.equals(otherKeywordTaskFilter.keywords);
+        return other instanceof KeywordTaskFilter;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/task/filters/KeywordTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/KeywordTaskFilter.java
@@ -1,5 +1,6 @@
 package seedu.address.model.task.filters;
 
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
@@ -32,5 +33,31 @@ public class KeywordTaskFilter extends TaskFilter {
     public String toDisplayString() {
         return (this.isInverted ? "Without " : "Contains ")
                 + StringUtil.limitString(keywords, "...", KeywordTaskFilter.MAX_KEYWORDS_LENGTH);
+    }
+
+    @Override
+    public boolean hasConflictWith(TaskFilter other) {
+        if (!(other instanceof KeywordTaskFilter)) {
+            return false;
+        }
+        KeywordTaskFilter otherKeywordTaskFilter = (KeywordTaskFilter) other;
+        return keywords.equals(otherKeywordTaskFilter.keywords);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        KeywordTaskFilter that = (KeywordTaskFilter) o;
+        return keywords.equals(that.keywords) && isInverted == that.isInverted;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(keywords, isInverted);
     }
 }

--- a/src/main/java/seedu/address/model/task/filters/TagTaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/TagTaskFilter.java
@@ -20,6 +20,15 @@ public class TagTaskFilter extends TaskFilter {
     }
 
     @Override
+    public boolean hasConflictWith(TaskFilter other) {
+        if (!(other instanceof TagTaskFilter)) {
+            return false;
+        }
+        TagTaskFilter otherTagTaskFilter = (TagTaskFilter) other;
+        return tag.equals(otherTagTaskFilter.tag);
+    }
+
+    @Override
     public TagTaskFilter invert() {
         return new TagTaskFilter(tag, !isInverted);
     }

--- a/src/main/java/seedu/address/model/task/filters/TaskFilter.java
+++ b/src/main/java/seedu/address/model/task/filters/TaskFilter.java
@@ -36,4 +36,6 @@ public abstract class TaskFilter {
      * @return the string used to describe the filter in the UI
      */
     public abstract String toDisplayString();
+
+    public abstract boolean hasConflictWith(TaskFilter other);
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -179,7 +179,7 @@ public class MainWindow extends UiPart<Stage> {
 
         TaskListPanel taskListPanel = new TaskListPanel(
                 logic.getFilteredTaskList(),
-                logic.getAvailableTaskFilters(),
+                logic.getSelectableTaskFilters(),
                 logic.getSelectedTaskFilters(),
                 logic::addTaskFilter,
                 logic::removeTaskFilter,

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -9,6 +9,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
@@ -39,24 +40,29 @@ public class TaskListPanel extends UiPart<Region> {
      */
     public TaskListPanel(
             ObservableList<Task> taskList,
-            ObservableList<TaskFilter> availableTaskFilters,
+            ObservableList<TaskFilter> selectableTaskFilters,
             ObservableList<TaskFilter> selectedTaskFilters,
             Consumer<TaskFilter> addTaskFilter,
             Consumer<TaskFilter> removeTaskFilter,
             Consumer<Task> addTask,
             TaskEditor taskEditor) {
         super("TaskListPanel.fxml");
-        this.availableTaskFilters = availableTaskFilters;
+        this.availableTaskFilters = selectableTaskFilters;
         this.selectedTaskFilters = selectedTaskFilters;
 
         // Initialize task list
         taskListView.setItems(taskList);
         taskListView.setCellFactory(tasks -> new TaskListViewCell(taskEditor));
 
-        // Initialize list of available filters
-        filterComboBox.setItems(availableTaskFilters);
+        // Initialize list of selectable filters
         filterComboBox.setCellFactory(taskFilters -> new TaskFilterCell());
         filterComboBox.setPromptText(null);
+        Label placeholder = new Label("No more filters");
+        placeholder.getStyleClass().add("italics");
+        filterComboBox.setPlaceholder(placeholder);
+        filterComboBox.setItems(selectableTaskFilters);
+        // Workaround: Close menu when mouse down to prevent mouse up from selecting another item
+        filterComboBox.setOnAction(e -> filterComboBox.hide());
         filterComboBox.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
             if (newValue != null) {
                 addTaskFilter.accept(newValue);

--- a/src/main/resources/view/Extensions.css
+++ b/src/main/resources/view/Extensions.css
@@ -16,6 +16,10 @@
     -fx-background: #383838;
 }
 
+.italics {
+    -fx-font-style: italic;
+}
+
 .tag-selector {
     -fx-border-width: 1;
     -fx-border-color: white;

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -165,7 +165,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public ObservableList<TaskFilter> getAvailableTaskFilters() {
+        public ObservableList<TaskFilter> getSelectableTaskFilters() {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/parser/task/ListTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/task/ListTaskCommandParserTest.java
@@ -32,7 +32,7 @@ public class ListTaskCommandParserTest {
 
     @Test
     void parse_showUndone_showUndoneTasks() {
-        assertParseSuccess(parser, " " + PREFIX_UNDONE, new ListTaskCommand(List.of(TaskFilters.FILTER_DONE.invert())));
+        assertParseSuccess(parser, " " + PREFIX_UNDONE, new ListTaskCommand(List.of(TaskFilters.FILTER_UNDONE)));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -18,6 +18,9 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.task.filters.TaskFilter;
+import seedu.address.model.task.filters.TaskFilters;
 import seedu.address.testutil.AddressBookBuilder;
 import seedu.address.testutil.TaskListBuilder;
 
@@ -94,6 +97,30 @@ public class ModelManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void getSelectableTaskFilters_withUndoneFilterApplied_doesNotContainDoneFilters() {
+        modelManager.addTaskFilter(TaskFilters.FILTER_UNDONE);
+        assertFalse(modelManager.getSelectableTaskFilters().contains(TaskFilters.FILTER_DONE));
+        assertFalse(modelManager.getSelectableTaskFilters().contains(TaskFilters.FILTER_UNDONE));
+    }
+
+    @Test
+    public void getSelectableTaskFilters_withDoneFilterApplied_doesNotContainDoneFilters() {
+        modelManager.addTaskFilter(TaskFilters.FILTER_DONE);
+        assertFalse(modelManager.getSelectableTaskFilters().contains(TaskFilters.FILTER_DONE));
+        assertFalse(modelManager.getSelectableTaskFilters().contains(TaskFilters.FILTER_UNDONE));
+    }
+
+    @Test
+    public void getSelectableTaskFilters_withTagFilterApplied_doesNotContainTagFilterAgain() {
+        TaskFilter filter = TaskFilters.FILTER_TAG.apply(new Tag("test"));
+        modelManager.addTaskFilter(filter);
+        assertTrue(modelManager.getSelectableTaskFilters().contains(TaskFilters.FILTER_DONE));
+        assertTrue(modelManager.getSelectableTaskFilters().contains(TaskFilters.FILTER_UNDONE));
+        assertTrue(modelManager.getSelectedTaskFilters().contains(filter));
+        assertFalse(modelManager.getSelectableTaskFilters().contains(filter));
     }
 
     @Test


### PR DESCRIPTION
Fixes the conflicts that may arise when adding task filters.

# Issue

Conflicts may happen when adding task filters (done and undone at the same time). Changes are made on both the GUI and Model level to prevent this from happening.

## Implementation

`Model.getAvailableTaskFilters` has been refactored to `Model.getSelectableTaskFilters`. This represents the filter options visible in the choice box at any point in time.

`Model.selectableTaskFilters` is calculated using a `FilteredList` with a predicate that matches only filters that do not `conflictWith` `Model.availableTaskFilters`.

## Conflict rules

The following rules are implemented with the abstract `hasConflictWith(TaskFilter filter)` method in `TaskFilter`.

- Only 1 instance of `DoneTaskFilter`
- Only 1 instance of `KeywordTaskFilter`
- Each `Tag` can only have one corresponding `TagFilter`

Fixes some inconsistencies in the DG.

# Related issues

Resolves #99
Resolves #152 