### PR TITLE
Fix clear undo

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -25,7 +25,10 @@ public class ClearCommand extends Command {
             throw new CommandException(Messages.MESSAGE_UNABLE_TO_EXECUTE);
         }
         requireNonNull(model);
-        this.oldAddressBook = model.getAddressBook();
+
+        // Save a copy of the previous AddressBook
+        this.oldAddressBook = new AddressBook(model.getAddressBook());
+
         model.setAddressBook(new AddressBook());
         this.canExecute = false;
         return new CommandResult(MESSAGE_SUCCESS);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -122,6 +122,7 @@ public class ModelManager implements Model {
     @Override
     public void setAddressBook(ReadOnlyAddressBook addressBook) {
         this.addressBook.resetData(addressBook);
+        updateAllTasksContacts();
     }
 
     @Override


### PR DESCRIPTION
Fixes #109.
Due to `setAddressBook()`, which calls `AddressBook#resetData()` and resets the `PersonList` rather than the `AddressBook` itself.

Also fixed a bug where `clear` does not update the presence of contacts in tasks.